### PR TITLE
Move swig before box2d-py in box2d deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = ["version"]
 # Update dependencies in `all` if any are added or removed
 atari = ["shimmy[atari] >=0.1.0,<1.0"]
 accept-rom-license = ["autorom[accept-rom-license] ~=0.4.2"]
-box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
+box2d = ["swig ==4.*", "box2d-py ==2.3.5", "pygame >=2.1.3"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
 mujoco-py = ["mujoco-py >=2.1,<2.2", "cython<3"]
@@ -58,9 +58,9 @@ all = [
     # atari
     "shimmy[atari] >=0.1.0,<1.0",
     # box2d
+    "swig ==4.*",
     "box2d-py ==2.3.5",
     "pygame >=2.1.3",
-    "swig ==4.*",
     # classic-control
     "pygame >=2.1.3",
     # mujoco-py


### PR DESCRIPTION
# Description

As described in #662, `gymnasium[box2d]` fails to install as `swig` cannot be found. This is in spite of `gymnasium[box2d]` depending on `swig` in `pyproject.toml`.

The current dependency list for `gymnasium[box2d]` lists `swig` _after_ `box2d`. In practice, pip installs dependencies in the order they are listed. Thus, when installing `gymnasium[box2d]`, pip will try to install `box2d-py` first, which requires `swig`, but `swig` will not be found.

To remedy this, I propose to move `swig` before `box2d-py` so that `swig` will be available when `box2d-py` is being built.

I understand that pip is documented as having no guarantees on installation order beyond topological order (https://pip.pypa.io/en/stable/cli/pip_install/#installation-order). However, in practice, at least on Linux, the ordering seems to be the order in which the dependencies are listed. I will note that `box2d-py` has no formal dependency on `swig`, so topological ordering does not apply here.

I believe current users have been getting around this issue by installing `swig` and then installing `gymnasium[box2d]`.

Fixes #662

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
